### PR TITLE
fix: Consumer::stop() compatibility with Laravel 12.61.1

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,14 +11,14 @@ Only the latest version will get new features. Bug fixes will be provided using 
 
 | Package Version | Laravel Version | Bug Fixes Until |                                                                                             |
 |-----------------|-----------------|-----------------|---------------------------------------------------------------------------------------------|
-| 1               | 62              | July 2th, 2026  | [Documentation](https://github.com/vyuldashev/laravel-queue-rabbitmq/blob/master/README.md) |
+| 1               | 64              | July 2th, 2026  | [Documentation](https://github.com/vyuldashev/laravel-queue-rabbitmq/blob/master/README.md) |
 
 ## Installation
 
 You can install this package via composer using this command:
 
 ```
-composer require salesmessage/php-lib-rabbitmq:^1.63 --ignore-platform-reqs
+composer require salesmessage/php-lib-rabbitmq:^1.64 --ignore-platform-reqs
 ```
 
 The package will automatically register itself.

--- a/composer.json
+++ b/composer.json
@@ -34,7 +34,7 @@
     },
     "extra": {
         "branch-alias": {
-            "dev-master": "1.63-dev"
+            "dev-master": "1.64-dev"
         },
         "laravel": {
             "providers": [

--- a/src/Consumer.php
+++ b/src/Consumer.php
@@ -224,9 +224,10 @@ class Consumer extends Worker
      *
      * @param  int  $status
      * @param  WorkerOptions|null  $options
+     * @param  \Illuminate\Queue\WorkerStopReason|null  $reason
      * @return int
      */
-    public function stop($status = 0, $options = null)
+    public function stop($status = 0, $options = null, $reason = null)
     {
         // Tell the server you are going to stop consuming.
         // It will finish up the last message and not send you any more.
@@ -239,6 +240,6 @@ class Consumer extends Worker
             ]);
         }
 
-        return parent::stop($status, $options);
+        return parent::stop($status, $options, $reason);
     }
 }


### PR DESCRIPTION
## Summary
- `Illuminate\Queue\Worker::stop()` gained a third `$reason` parameter in `laravel/framework` 12.61.1, making this override's signature incompatible and causing a fatal error on boot.
- Same issue as salesmessage/laravel-queue-rabbitmq#34.

## Test plan
- [ ] Consumers boot without fatal error under laravel/framework ^12.61.1