### PR TITLE
fix: AbstractVhostsConsumer::kill() compatibility with Laravel 12.61.1

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,14 +11,14 @@ Only the latest version will get new features. Bug fixes will be provided using 
 
 | Package Version | Laravel Version | Bug Fixes Until |                                                                                             |
 |-----------------|-----------------|-----------------|---------------------------------------------------------------------------------------------|
-| 1               | 64              | July 2th, 2026  | [Documentation](https://github.com/vyuldashev/laravel-queue-rabbitmq/blob/master/README.md) |
+| 1               | 65              | July 2th, 2026  | [Documentation](https://github.com/vyuldashev/laravel-queue-rabbitmq/blob/master/README.md) |
 
 ## Installation
 
 You can install this package via composer using this command:
 
 ```
-composer require salesmessage/php-lib-rabbitmq:^1.64 --ignore-platform-reqs
+composer require salesmessage/php-lib-rabbitmq:^1.65 --ignore-platform-reqs
 ```
 
 The package will automatically register itself.

--- a/composer.json
+++ b/composer.json
@@ -34,7 +34,7 @@
     },
     "extra": {
         "branch-alias": {
-            "dev-master": "1.64-dev"
+            "dev-master": "1.65-dev"
         },
         "laravel": {
             "providers": [

--- a/src/VhostsConsumers/AbstractVhostsConsumer.php
+++ b/src/VhostsConsumers/AbstractVhostsConsumer.php
@@ -1069,13 +1069,13 @@ abstract class AbstractVhostsConsumer extends Consumer
         pcntl_alarm($timeout);
     }
 
-    public function kill($status = 0, $options = null)
+    public function kill($status = 0, $options = null, $reason = null)
     {
         $this->logger->error('Stopped job execution.', [
             'status' => $status,
             'options' => $options,
         ]);
 
-        parent::kill($status, $options);
+        parent::kill($status, $options, $reason);
     }
 }


### PR DESCRIPTION
## Summary
- Illuminate\Queue\Worker::kill() gained a third $reason parameter in laravel/framework 12.61.1, making this override's signature incompatible and causing a fatal error on boot.
- Same pattern as #53 (Consumer::stop()), applied to AbstractVhostsConsumer::kill().
- Bumps dev-master branch-alias to 1.65-dev.

## Test plan
- [ ] Consumers/vhost workers boot without fatal error under laravel/framework ^12.61.1