### PR TITLE
fix: make shouldConfirmOnPublish() truly optional, as documented

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -34,7 +34,7 @@
     },
     "extra": {
         "branch-alias": {
-            "dev-master": "1.65-dev"
+            "dev-master": "1.66-dev"
         },
         "laravel": {
             "providers": [

--- a/src/Contracts/RabbitMQConsumable.php
+++ b/src/Contracts/RabbitMQConsumable.php
@@ -4,6 +4,10 @@ namespace Salesmessage\LibRabbitMQ\Contracts;
 
 /**
  * Each Laravel job should implement this interface.
+ *
+ * A job may additionally define `shouldConfirmOnPublish(): bool` to opt into publisher
+ * confirms. It's intentionally not part of this interface: it's detected via
+ * method_exists(), so jobs that don't implement it keep the fire-and-forget publish path.
  */
 interface RabbitMQConsumable
 {
@@ -17,6 +21,4 @@ interface RabbitMQConsumable
     public function isDuplicated(): bool;
 
     public function getQueueType(): string;
-
-    public function shouldConfirmOnPublish(): bool;
 }

--- a/src/Queue/Jobs/RabbitMQJob.php
+++ b/src/Queue/Jobs/RabbitMQJob.php
@@ -145,7 +145,9 @@ class RabbitMQJob extends Job implements JobContract
             ? $consumableJob->getQueueType()
             : RabbitMQConsumable::MQ_TYPE_QUORUM;
 
-        $confirm = ($consumableJob instanceof RabbitMQConsumable) && $consumableJob->shouldConfirmOnPublish();
+        $confirm = ($consumableJob instanceof RabbitMQConsumable)
+            && method_exists($consumableJob, 'shouldConfirmOnPublish')
+            && $consumableJob->shouldConfirmOnPublish();
 
         // Always create a new message when this Job is released
         $this->rabbitmq->laterRaw(

--- a/src/Queue/RabbitMQQueue.php
+++ b/src/Queue/RabbitMQQueue.php
@@ -1017,7 +1017,9 @@ class RabbitMQQueue extends Queue implements QueueContract, RabbitMQQueueContrac
 
     protected function jobRequestsConfirm($job): bool
     {
-        return $job instanceof RabbitMQConsumable && $job->shouldConfirmOnPublish();
+        return $job instanceof RabbitMQConsumable
+            && method_exists($job, 'shouldConfirmOnPublish')
+            && $job->shouldConfirmOnPublish();
     }
 
     protected function createChannel(): AMQPChannel


### PR DESCRIPTION
## Summary
- RabbitMQConsumable declared shouldConfirmOnPublish() as a required abstract method, contradicting the README which says it's detected via method_exists() and existing jobs don't need to change.
- Any non-abstract class implementing RabbitMQConsumable without this method fatals at boot (Non-abstract class ... contains abstract method shouldConfirmOnPublish()).
- Removes it from the interface; gates both call sites (RabbitMQJob::release(), RabbitMQQueue::jobRequestsConfirm()) with method_exists(), matching documented behavior.
- Bumps dev-master branch-alias to 1.66-dev.

## Test plan
- [ ] Jobs implementing RabbitMQConsumable without shouldConfirmOnPublish() boot without fatal error
- [ ] Jobs that do implement shouldConfirmOnPublish() still get publisher confirms