### PR TITLE
SWC-18827 fix: add --stop-when-empty-for to ConsumeVhostsCommand sign…

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,14 +11,14 @@ Only the latest version will get new features. Bug fixes will be provided using 
 
 | Package Version | Laravel Version | Bug Fixes Until |                                                                                             |
 |-----------------|-----------------|-----------------|---------------------------------------------------------------------------------------------|
-| 1               | 65              | July 2th, 2026  | [Documentation](https://github.com/vyuldashev/laravel-queue-rabbitmq/blob/master/README.md) |
+| 1               | 66              | July 2th, 2026  | [Documentation](https://github.com/vyuldashev/laravel-queue-rabbitmq/blob/master/README.md) |
 
 ## Installation
 
 You can install this package via composer using this command:
 
 ```
-composer require salesmessage/php-lib-rabbitmq:^1.65 --ignore-platform-reqs
+composer require salesmessage/php-lib-rabbitmq:^1.66 --ignore-platform-reqs
 ```
 
 The package will automatically register itself.

--- a/composer.json
+++ b/composer.json
@@ -34,7 +34,7 @@
     },
     "extra": {
         "branch-alias": {
-            "dev-master": "1.65-dev"
+            "dev-master": "1.66-dev"
         },
         "laravel": {
             "providers": [

--- a/src/Console/ConsumeVhostsCommand.php
+++ b/src/Console/ConsumeVhostsCommand.php
@@ -21,6 +21,7 @@ class ConsumeVhostsCommand extends WorkCommand
                             {--name=default : The name of the consumer}
                             {--once : Only process the next job on the queue}
                             {--stop-when-empty : Stop when the queue is empty}
+                            {--stop-when-empty-for=0 : Stop when no jobs have been processed for the given number of seconds}
                             {--delay=0 : The number of seconds to delay failed jobs (Deprecated)}
                             {--backoff=0 : The number of seconds to wait before retrying a job that encountered an uncaught exception}
                             {--max-jobs=0 : The number of jobs to process before stopping}


### PR DESCRIPTION
…ature

Laravel 12.60+ WorkCommand::gatherWorkerOptions() reads this option unconditionally, but ConsumeVhostsCommand redeclares its own $signature and never inherited it, causing InvalidArgumentException on startup.